### PR TITLE
fix: IOS audio autoplay workaround

### DIFF
--- a/src/components/gameTable/TableAudio.tsx
+++ b/src/components/gameTable/TableAudio.tsx
@@ -26,7 +26,7 @@ interface TableAudioProps {
 
 const mapStateToProps = (state: State) => ({
 	soundVolume: state.settings.soundVolume,
-	audio: state.run.table.audio.replace('https://vladimirkhil.com/siserver/3', 'http://192.168.100.3:5005'),
+	audio: state.run.table.audio,
 	isMediaStopped: state.run.stage.isGamePaused || state.run.table.isMediaStopped
 });
 
@@ -49,7 +49,6 @@ export class TableAudio extends React.Component<TableAudioProps> {
 	private audioRef: HTMLAudioElement = AUDIO_OBJECT;
 
 	componentDidMount() {
-		console.log(this.audioRef);
 		this.audioRef.volume = this.props.soundVolume;
 		this.audioRef.loop = false;
 		const audio = this.audioRef;
@@ -61,11 +60,9 @@ export class TableAudio extends React.Component<TableAudioProps> {
 			this.props.operationError(`${localization.unsupportedMediaType}: ${ext}`);
 		} else {
 			audio.onload = () => {
-				console.log('load');
 				this.props.mediaLoaded();
 			};
 			audio.onended = () => {
-				console.log('endaudio');
 				this.props.onMediaEnded();
 			};
 			audio.src = this.props.audio;
@@ -81,7 +78,6 @@ export class TableAudio extends React.Component<TableAudioProps> {
 		const audio = this.audioRef;
 
 		if (this.props.audio !== audio.currentSrc) {
-			console.log(this.props.audio);
 			audio.src = this.props.audio;
 			audio.load();
 		}

--- a/src/components/gameTable/TableAudio.tsx
+++ b/src/components/gameTable/TableAudio.tsx
@@ -9,6 +9,10 @@ import getErrorMessage from '../../utils/ErrorHelpers';
 import getExtension from '../../utils/FileHelper';
 import localization from '../../model/resources/localization';
 
+const EMPTY_WAV_SOUND =
+	'data:audio/wav;base64,UklGRjIAAABXQVZFZm10IBIAAAABAAEAQB8AAEAfAAABAAgAAABmYWN0BAAAAAAAAABkYXRhAAAAAA==';
+export const AUDIO_OBJECT = new Audio(EMPTY_WAV_SOUND);
+
 interface TableAudioProps {
 	soundVolume: number;
 	audio: string;
@@ -22,7 +26,7 @@ interface TableAudioProps {
 
 const mapStateToProps = (state: State) => ({
 	soundVolume: state.settings.soundVolume,
-	audio: state.run.table.audio,
+	audio: state.run.table.audio.replace('https://vladimirkhil.com/siserver/3', 'http://192.168.100.3:5005'),
 	isMediaStopped: state.run.stage.isGamePaused || state.run.table.isMediaStopped
 });
 
@@ -38,41 +42,47 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
 	},
 	mediaLoaded: () => {
 		dispatch(runActionCreators.mediaLoaded() as unknown as Action);
-	},
+	}
 });
 
 export class TableAudio extends React.Component<TableAudioProps> {
-	private audioRef: React.RefObject<HTMLAudioElement>;
-
-	constructor(props: TableAudioProps) {
-		super(props);
-
-		this.audioRef = React.createRef();
-	}
+	private audioRef: HTMLAudioElement = AUDIO_OBJECT;
 
 	componentDidMount() {
-		if (!this.audioRef.current) {
-			return;
-		}
+		console.log(this.audioRef);
+		this.audioRef.volume = this.props.soundVolume;
+		this.audioRef.loop = false;
+		const audio = this.audioRef;
 
-		this.audioRef.current.volume = this.props.soundVolume;
-		
 		const ext = getExtension(this.props.audio);
-		const canPlay = ext !== null && this.audioRef.current.canPlayType('audio/' + ext);
+		const canPlay = ext !== null && this.audioRef.canPlayType('audio/' + ext);
 
 		if (canPlay === '') {
 			this.props.operationError(`${localization.unsupportedMediaType}: ${ext}`);
+		} else {
+			audio.onload = () => {
+				console.log('load');
+				this.props.mediaLoaded();
+			};
+			audio.onended = () => {
+				console.log('endaudio');
+				this.props.onMediaEnded();
+			};
+			audio.src = this.props.audio;
+			audio.load();
+			audio.play().catch((e) => this.props.operationError(getErrorMessage(e)));
+			if (audio.readyState >= 3) {
+				this.props.mediaLoaded();
+			}
 		}
 	}
 
 	componentDidUpdate(prevProps: TableAudioProps) {
-		const audio = this.audioRef.current;
-
-		if (!audio) {
-			return;
-		}
+		const audio = this.audioRef;
 
 		if (this.props.audio !== audio.currentSrc) {
+			console.log(this.props.audio);
+			audio.src = this.props.audio;
 			audio.load();
 		}
 
@@ -80,22 +90,23 @@ export class TableAudio extends React.Component<TableAudioProps> {
 			if (this.props.isMediaStopped) {
 				audio.pause();
 			} else {
-				audio.play().catch(e => this.props.operationError(getErrorMessage(e)));
+				audio.play().catch((e) => this.props.operationError(getErrorMessage(e)));
 			}
 		}
 
 		audio.volume = this.props.soundVolume;
 	}
 
+	onEnableAudioPlay = () => {
+		this.audioRef.play();
+	};
+
 	render() {
-		const { onMediaEnded, audio } = this.props;
+		const { audio } = this.props;
 
 		return audio.length === 0 ? null : (
 			<>
-				<audio ref={this.audioRef} autoPlay onEnded={onMediaEnded} onLoadedData={() => this.props.mediaLoaded()}>
-					<source src={audio} />
-				</audio>
-				<VolumeButton />
+				<VolumeButton onEnableAudioPlay={this.onEnableAudioPlay} />
 			</>
 		);
 	}

--- a/src/components/gameTable/TableVideo.tsx
+++ b/src/components/gameTable/TableVideo.tsx
@@ -34,7 +34,7 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
 	},
 	mediaLoaded: () => {
 		dispatch(runActionCreators.mediaLoaded() as unknown as Action);
-	},
+	}
 });
 
 export class TableVideo extends React.Component<TableVideoProps> {
@@ -52,7 +52,7 @@ export class TableVideo extends React.Component<TableVideoProps> {
 		}
 
 		this.videoRef.current.volume = this.props.soundVolume;
-		
+
 		const ext = getExtension(this.props.text);
 		const canPlay = ext !== null && this.videoRef.current.canPlayType('video/' + ext);
 
@@ -76,12 +76,18 @@ export class TableVideo extends React.Component<TableVideoProps> {
 			if (this.props.isMediaStopped) {
 				video.pause();
 			} else {
-				video.play().catch(e => this.props.operationError(getErrorMessage(e)));
+				video.play().catch((e) => this.props.operationError(getErrorMessage(e)));
 			}
 		}
 
 		video.volume = this.props.soundVolume;
 	}
+
+	onEnableAudioPlay = () => {
+		if (this.videoRef.current) {
+			this.videoRef.current.play();
+		}
+	};
 
 	render() {
 		const { onMediaEnded, text } = this.props;
@@ -91,7 +97,7 @@ export class TableVideo extends React.Component<TableVideoProps> {
 				<video ref={this.videoRef} autoPlay onEnded={onMediaEnded} onLoadedData={() => this.props.mediaLoaded()}>
 					<source src={text} />
 				</video>
-				<VolumeButton />
+				<VolumeButton onEnableAudioPlay={this.onEnableAudioPlay} />
 			</TableBorder>
 		);
 	}

--- a/src/components/gameTable/TableVideo.tsx
+++ b/src/components/gameTable/TableVideo.tsx
@@ -86,6 +86,7 @@ export class TableVideo extends React.Component<TableVideoProps> {
 	onEnableAudioPlay = () => {
 		if (this.videoRef.current) {
 			this.videoRef.current.play();
+			this.videoRef.current.muted = false;
 		}
 	};
 


### PR DESCRIPTION
Костыль чтобы заставить autoplay работать хоть как-то на иос.
Небольшое обьяснение что вообще происходит:
Браузеры (в особенности как оказалось больше именно ios safari) имеют некотоыре ограничения свяазнные с autoplay, то есть по умолчанию аудио не может воспроизводитсья сразу как заходишь на страницу, сделано это для того чтобы улучшить UX, для того чтобы аудио воспроизводилось нужно чтобы это дейтсвие было инциализировано пользователем. Если говорить конкретно о мобильном ios, то autoplay там в целом не работает почти совсем, любое воспроизведение звука должно находитсья так называемом trusted контексте (конктекст будет таким считать если именно юзер кликнул на кнопку и сработал onclick, програмные действия таким не считаются), это значит что возможность воспроизвости, скажем так, легально звук без участия пользователя фактически невозможно, так что пришлось пойти на некоторые ухищрения.

Первое, для начала с помощью апи AudioContext мы можем проверить наше текущее состояние или лучше сказать права для запуска аудио, если доступа нет я сделал так чтоыб показывало иконку "без звука" и для воспроизведения видео нужно кликнуть по иконке которые в свою очередь создаст trusted контекст из которого мы сможем воспроизвести аудио, проблема здесь в том что в этом случае так придётся делать с каждым аудио...

Второе, как можно избежать поведения когда нужно каждый раз нажимать на кнопку чтобы заиграло видео? Все аудио мы можем воспроизводить сугубо через один единственный Audio элемент, просто меняя у него src, если Audio было уже запущенно из trusted контекста, то мы можем его использовать вместо того чтобы создавать каждый отдельный audio тэг. Единственный момент что первый раз его в любом случае нужно запускать из trusted контекста, для этого можно скомбинировать его с первым подходом.

**Важно!**
Не могу сказать что достаточно глубоко разбираюсь в этой теме, я попробовал несколько разных подходов, этот способ может и не самый удобный, но должен работать, **но** у меня есть подозрение что trusted контекст через время может слетать с Audio если им не пользуются, нужно этот кейс проверить, вроде между раундами всё нормально было (в некоторых подходах летел AbortError в непонятных местах, в этом не замечал пробелмы), на крайний случай можно в моменты простоя воспроизводить пустой звук.