### PR TITLE
Clear room state on player's leave

### DIFF
--- a/src/components/common/ChatInputEmojiPicker.css
+++ b/src/components/common/ChatInputEmojiPicker.css
@@ -9,6 +9,7 @@
     position: absolute;
     right: 0;
     bottom: 0;
+    width: 10%;
 }
 
 aside.EmojiPickerReact.epr-main {

--- a/src/state/room/RoomActions.ts
+++ b/src/state/room/RoomActions.ts
@@ -87,6 +87,7 @@ export const enum RoomActionTypes {
 	SelectBannedItem = 'SELECT_BANNED_ITEM',
 	PlayerMediaLoaded = 'PLAYER_MEDIA_LOADED',
 	EditTable = 'EDIT_TABLE',
+	ClearRoomChat = 'ROOM_CHAT_CLEAR',
 }
 
 export type RunChatModeChangedAction = { type: RoomActionTypes.RoomChatModeChanged, chatMode: ChatMode };
@@ -135,6 +136,7 @@ export type ClearDecisionsAction = { type: RoomActionTypes.ClearDecisions };
 export type IsGameButtonEnabledChangedAction = { type: RoomActionTypes.IsGameButtonEnabledChanged, isGameButtonEnabled: boolean };
 export type IsAnsweringAction = { type: RoomActionTypes.IsAnswering };
 export type AnswerChangedAction = { type: RoomActionTypes.AnswerChanged, answer: string };
+export type ClearRoomChatAction = { type: RoomActionTypes.ClearRoomChat };
 
 export type ValidateAction = {
 	type: RoomActionTypes.Validate,
@@ -266,4 +268,5 @@ export type KnownRoomAction =
 	| UnbannedAction
 	| SelectBannedItemAction
 	| PlayerMediaLoadedAction
-	| EditTableAction;
+	| EditTableAction
+	| ClearRoomChatAction;

--- a/src/state/room/roomActionCreators.ts
+++ b/src/state/room/roomActionCreators.ts
@@ -152,6 +152,7 @@ const exitGame: ActionCreator<ThunkAction<void, State, DataContext, Action>> = (
 	}
 
 	dispatch(tableActionCreators.tableReset());
+	dispatch(gameStateCleared());
 
 	dispatch(stopTimer(0));
 	dispatch(stopTimer(1));

--- a/src/state/room/roomActionCreators.ts
+++ b/src/state/room/roomActionCreators.ts
@@ -152,7 +152,7 @@ const exitGame: ActionCreator<ThunkAction<void, State, DataContext, Action>> = (
 	}
 
 	dispatch(tableActionCreators.tableReset());
-	dispatch(gameStateCleared());
+	dispatch(clearRoomChat());
 
 	dispatch(stopTimer(0));
 	dispatch(stopTimer(1));
@@ -782,6 +782,10 @@ const mediaLoaded: ActionCreator<ThunkAction<void, State, DataContext, Action>> 
 	await dataContext.game.mediaLoaded();
 };
 
+const clearRoomChat: ActionCreator<RunActions.ClearRoomChatAction> = () => ({
+	type: RunActions.RoomActionTypes.ClearRoomChat
+});
+
 const roomActionCreators = {
 	runChatModeChanged,
 	runChatMessageChanged,
@@ -896,6 +900,7 @@ const roomActionCreators = {
 	unban,
 	playerMediaLoaded,
 	mediaLoaded,
+	clearRoomChat,
 };
 
 export default roomActionCreators;

--- a/src/state/room/roomReducer.ts
+++ b/src/state/room/roomReducer.ts
@@ -256,6 +256,11 @@ const roomReducer: Reducer<RoomState> = (state: RoomState = initialState, anyAct
 					areVisible: false,
 					areSimple: false
 				},
+				chat: {
+					...state.chat,
+					messages: [],
+					message: ''
+				}
 			};
 
 		case RoomActionTypes.SumsChanged:

--- a/src/state/room/roomReducer.ts
+++ b/src/state/room/roomReducer.ts
@@ -255,7 +255,12 @@ const roomReducer: Reducer<RoomState> = (state: RoomState = initialState, anyAct
 					...state.stakes,
 					areVisible: false,
 					areSimple: false
-				},
+				}
+			};
+
+		case RoomActionTypes.ClearRoomChat:
+			return {
+				...state,
 				chat: {
 					...state.chat,
 					messages: [],


### PR DESCRIPTION
This PR  adds room state cleanup when player is leaving (exiting).
Also it fixes the gap in Lobby chat between input and emoji button. 