### PR TITLE
Fix the chat window blow up to full screen if a very long message was sent

### DIFF
--- a/src/components/game/InGameView.css
+++ b/src/components/game/InGameView.css
@@ -7,6 +7,7 @@
 .game__mainArea {
     display: flex;
     flex-direction: column;
+    overflow-x: hidden;
 }
 
 .game__tableArea {

--- a/src/style.css
+++ b/src/style.css
@@ -408,7 +408,8 @@ h1.activeTab {
     flex: 1 0 0;
     background-color: #000451;
     color: white;
-    max-width: 300px;
+    overflow-x: hidden;
+    overflow-wrap: break-word;
 }
 
 .game__log {

--- a/src/style.css
+++ b/src/style.css
@@ -408,6 +408,7 @@ h1.activeTab {
     flex: 1 0 0;
     background-color: #000451;
     color: white;
+    max-width: 300px;
 }
 
 .game__log {


### PR DESCRIPTION
If a player sends a very long message, the chat window blows up to the entire screen, covering the game interface. Setting `max-with` for the `game__chat` class fixes this problem.

![image](https://github.com/VladimirKhil/SIOnline/assets/22778376/8c36bf67-dc81-42f8-88f8-dceb58444d6f)
