### PR TITLE
Show media preload progress continuously; support showman

### DIFF
--- a/src/components/game/PlayerView/PlayerView.tsx
+++ b/src/components/game/PlayerView/PlayerView.tsx
@@ -313,7 +313,7 @@ export function PlayerView(props: PlayerViewProps): JSX.Element {
 					) : null}
 				</div>
 
-				{player.mediaPreloadProgress > 0 && player.mediaPreloadProgress <= 100 ? (
+				{account && player.mediaPreloadStarted ? (
 					<div className='preload__progress'>
 						<div className="preload__bar" style={{ width: `${player.mediaPreloadProgress}%` }} title={localization.mediaPreloadProgress} />
 						<span className="preload__text">{localization.loading}: {player.mediaPreloadProgress}%</span>

--- a/src/components/game/ShowmanReplicView/ShowmanReplicView.scss
+++ b/src/components/game/ShowmanReplicView/ShowmanReplicView.scss
@@ -72,6 +72,43 @@
     height: 100%;
 }
 
+.showmanAvatar .preload__progress {
+    position: absolute;
+    top: 5px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80%;
+    z-index: 5;
+    height: 16px;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.showmanAvatar .preload__bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background: linear-gradient(90deg, rgba(76, 175, 80, 0.8), rgba(46, 125, 50, 0.8));
+    border-radius: 10px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    transition: width 0.3s ease;
+}
+
+.showmanAvatar .preload__text {
+    position: relative;
+    z-index: 10;
+    color: white;
+    font-size: 10px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+    white-space: nowrap;
+}
+
 .showmanName {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/game/ShowmanReplicView/ShowmanReplicView.tsx
+++ b/src/components/game/ShowmanReplicView/ShowmanReplicView.tsx
@@ -45,6 +45,8 @@ export function ShowmanReplicView(props: ShowmanReplicViewProps): JSX.Element {
 	const windowWidth = useAppSelector(state => state.ui.windowWidth);
 	const deepMode = useAppSelector(state => state.room2.deepMode);
 	const role = useAppSelector(state => state.room2.role);
+	const mediaPreloadStarted = useAppSelector(state => state.room2.persons.showman.mediaPreloadStarted);
+	const mediaPreloadProgress = useAppSelector(state => state.room2.persons.showman.mediaPreloadProgress);
 
 	const isScreenWide = windowWidth >= Constants.WIDE_WINDOW_WIDTH;
 	const activePlayer = !isScreenWide && replicIndex > -1 && replicIndex < players.length
@@ -72,6 +74,13 @@ export function ShowmanReplicView(props: ShowmanReplicViewProps): JSX.Element {
 
 	const avatarClass = getAvatarClass(account);
 
+	const showmanPreload = !activePlayer && account && mediaPreloadStarted ? (
+		<div className='preload__progress'>
+			<div className="preload__bar" style={{ width: `${mediaPreloadProgress ?? 0}%` }} title={localization.mediaPreloadProgress} />
+			<span className="preload__text">{localization.loading}: {mediaPreloadProgress ?? 0}%</span>
+		</div>
+	) : null;
+
 	const showmanInfoStyle: React.CSSProperties = isGameStarted && !activePlayer ? {} : {
 		display: 'flex'
 	};
@@ -88,8 +97,8 @@ export function ShowmanReplicView(props: ShowmanReplicViewProps): JSX.Element {
 				{!deepMode ? (
 					<>
 						{props.showVideoAvatars && account?.avatarVideo
-							? <div className='showmanAvatar'><iframe title='Video avatar' src={account?.avatarVideo} /></div>
-							: <div className={`showmanAvatar ${avatarClass}`} style={avatarStyle} />}
+							? <div className='showmanAvatar'><iframe title='Video avatar' src={account?.avatarVideo} />{showmanPreload}</div>
+							: <div className={`showmanAvatar ${avatarClass}`} style={avatarStyle}>{showmanPreload}</div>}
 
 						<div className="showmanName">
 							{isReady && !isGameStarted ? (

--- a/src/logic/ClientController.ts
+++ b/src/logic/ClientController.ts
@@ -106,6 +106,7 @@ import {
 	playersAnswersChanged,
 	playersStateCleared,
 	playersSwap,
+	swapShowmanPlayerMediaPreload,
 	questionAnswersChanged,
 	selectPlayers,
 	setContext,
@@ -136,6 +137,7 @@ import {
 	addToChat,
 	setJoinMode,
 	showMediaPreloadProgress,
+	startRoundContentPreload,
 	setRoundsNames,
 	setShowMainTimer,
 	runTimer,
@@ -1180,6 +1182,8 @@ export default class ClientController implements IClientController {
 	}
 
 	onRoundContent(content: string[]) {
+		this.appDispatch(startRoundContentPreload());
+
 		preloadRoundContent(
 			content,
 			this.preprocessServerUri.bind(this),
@@ -2064,6 +2068,7 @@ export default class ClientController implements IClientController {
 		if (state.room2.persons.showman.name === replacer) { // isPlayer
 			this.appDispatch(showmanChanged({ name: account.name, isHuman: true, isReady: account.isReady }));
 			this.appDispatch(playerChanged({ index, name: replacer, isHuman: true, isReady: state.room2.persons.showman.isReady }));
+			this.appDispatch(swapShowmanPlayerMediaPreload(index));
 
 			if (account.name === state.room2.name) {
 				this.setCurrentRoomRole(Role.Showman);
@@ -2083,6 +2088,7 @@ export default class ClientController implements IClientController {
 
 					this.appDispatch(playerChanged({ index: i, name: account.name, isReady: account.isReady }));
 					this.appDispatch(showmanChanged({ name: replacer, isReady }));
+					this.appDispatch(swapShowmanPlayerMediaPreload(i));
 
 					if (state.room2.persons.showman.name === state.room2.name) {
 						this.setCurrentRoomRole(Role.Player);

--- a/src/logic/messageProcessor.ts
+++ b/src/logic/messageProcessor.ts
@@ -1226,7 +1226,9 @@ function info(controller: ClientController, ...args: string[]) {
 		isReady,
 		replic: null,
 		isDeciding: false,
-		isHuman
+		isHuman,
+		mediaPreloadProgress: 0,
+		mediaPreloadStarted: false
 	};
 
 	if (isConnected) {

--- a/src/model/PersonInfo.ts
+++ b/src/model/PersonInfo.ts
@@ -4,4 +4,6 @@ export default interface PersonInfo {
 	replic: string | null;
 	isDeciding: boolean;
 	isHuman: boolean;
+	mediaPreloadProgress?: number;
+	mediaPreloadStarted?: boolean;
 }

--- a/src/state/room2Slice.ts
+++ b/src/state/room2Slice.ts
@@ -629,6 +629,55 @@ export const room2Slice = createSlice({
 					return;
 				}
 			}
+
+			if (state.persons.showman.name === action.payload.playerName) {
+				state.persons.showman.mediaPreloadProgress = action.payload.progress;
+			}
+		},
+		roundContentPreloadStarted(state: Room2State) {
+			// Only occupied seats: an empty seat marked here would show a stuck 0% bar
+			// once a late joiner sits down without going through this round's preload.
+			state.persons.players.forEach(p => {
+				if (state.persons.all[p.name]) {
+					p.mediaPreloadStarted = true;
+					p.mediaPreloadProgress = 0;
+				}
+			});
+
+			if (state.persons.all[state.persons.showman.name]) {
+				state.persons.showman.mediaPreloadStarted = true;
+				state.persons.showman.mediaPreloadProgress = 0;
+			}
+		},
+		hideMediaPreload(state: Room2State, action: PayloadAction<string>) {
+			for (let i = 0; i < state.persons.players.length; i += 1) {
+				if (state.persons.players[i].name === action.payload) {
+					state.persons.players[i].mediaPreloadStarted = false;
+					return;
+				}
+			}
+
+			if (state.persons.showman.name === action.payload) {
+				state.persons.showman.mediaPreloadStarted = false;
+			}
+		},
+		swapShowmanPlayerMediaPreload(state: Room2State, action: PayloadAction<number>) {
+			// The preload bar is stored per seat but belongs to the person; when the showman and a
+			// player swap seats, carry it over so each person keeps their own progress (playersSwap
+			// already does this for player-to-player swaps by swapping whole objects).
+			const player = state.persons.players[action.payload];
+
+			if (!player) {
+				return;
+			}
+
+			const { showman } = state.persons;
+			const startedTemp = showman.mediaPreloadStarted;
+			const progressTemp = showman.mediaPreloadProgress;
+			showman.mediaPreloadStarted = player.mediaPreloadStarted;
+			showman.mediaPreloadProgress = player.mediaPreloadProgress;
+			player.mediaPreloadStarted = startedTemp;
+			player.mediaPreloadProgress = progressTemp ?? 0;
 		},
 		setHostName(state: Room2State, action: PayloadAction<string | null>) {
 			state.persons.hostName = action.payload;
@@ -1066,6 +1115,11 @@ export const pressGameButton = createAsyncThunk(
 
 const timeoutIds: Record<string, NodeJS.Timeout> = {};
 
+// Keep the preload bar visible for 10s after reaching 100%, then hide it.
+const PRELOAD_COMPLETE_HIDE_DELAY = 10000;
+// Safety net: hide a preload bar after a minute without any progress updates.
+const PRELOAD_IDLE_HIDE_DELAY = 60000;
+
 export const showMediaPreloadProgress = createAsyncThunk(
 	'room2/showMediaPreloadProgress',
 	async (arg: { playerName: string, progress: number }, thunkAPI) => {
@@ -1076,12 +1130,24 @@ export const showMediaPreloadProgress = createAsyncThunk(
 
 		thunkAPI.dispatch(room2Slice.actions.setPlayerMediaPreloadProgress(arg));
 
+		const hideDelay = arg.progress >= 100 ? PRELOAD_COMPLETE_HIDE_DELAY : PRELOAD_IDLE_HIDE_DELAY;
+
 		timeoutIds[arg.playerName] = setTimeout(() => {
-			thunkAPI.dispatch(room2Slice.actions.setPlayerMediaPreloadProgress({
-				playerName: arg.playerName,
-				progress: 0,
-			}));
-		}, 10000);
+			delete timeoutIds[arg.playerName];
+			thunkAPI.dispatch(room2Slice.actions.hideMediaPreload(arg.playerName));
+		}, hideDelay);
+	},
+);
+
+export const startRoundContentPreload = createAsyncThunk(
+	'room2/startRoundContentPreload',
+	async (_arg: void, thunkAPI) => {
+		Object.keys(timeoutIds).forEach(name => {
+			clearTimeout(timeoutIds[name]);
+			delete timeoutIds[name];
+		});
+
+		thunkAPI.dispatch(room2Slice.actions.roundContentPreloadStarted());
 	},
 );
 
@@ -1265,6 +1331,7 @@ export const {
 	playerMediaLoaded,
 	playerMediaPreloaded,
 	setPlayerMediaPreloadProgress,
+	swapShowmanPlayerMediaPreload,
 	setHostName,
 	personAdded,
 	personRemoved,

--- a/src/utils/DemoGameClient.ts
+++ b/src/utils/DemoGameClient.ts
@@ -104,6 +104,8 @@ export default class DemoGameClient implements IGameClient {
 				isHuman: false,
 				replic: '',
 				isDeciding: false,
+				mediaPreloadProgress: 0,
+				mediaPreloadStarted: false,
 			},
 			[{
 				name: localization.player + ' 1',


### PR DESCRIPTION
## Summary
- Player media-preload progress bar now stays visible continuously from round start until the player finishes loading, instead of flickering/disappearing early.
- The showman now also gets a media-preload progress indicator (previously only players had one).
- Fixed edge cases: no stale bar shown for empty seats, no stuck 0% bar for a player who joins an empty seat mid-round, and progress correctly follows the person (not the seat) when the showman and a player swap places.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (no new errors/warnings introduced)
- [x] `npm test` (no new failures introduced)
- [x] Manual: two clients in a room, verify player progress bar shows continuously through preload and hides ~10s after reaching 100%
- [x] Manual: showman progress bar shows and behaves the same way
- [x] Manual: empty seats show no progress bar
- [x] Manual: a third client joining an empty seat mid-round does not show a stuck 0% bar for other clients
- [x] Manual: swapping showman and a player mid-preload carries each person's own progress with them