### PR TITLE
Отдельная кнопка для полноэкранного режима

### DIFF
--- a/src/components/panels/FullScreenButton/FullScreenButton.css
+++ b/src/components/panels/FullScreenButton/FullScreenButton.css
@@ -1,0 +1,27 @@
+.fullScreenButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    border: 0;
+    height: 100%;
+    width: 45px;
+    background: transparent;
+    color: #FFFFFF;
+    transition: all 0.2s ease;
+}
+
+.fullScreenButton svg {
+    width: 100%;
+    height: 100%;
+}
+
+.fullScreenButton:hover {
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 12px rgba(255, 255, 255, 0.2);
+}
+
+.fullScreenButton:active {
+    background: rgba(255, 255, 255, 0.3);
+    transform: scale(0.95);
+}

--- a/src/components/panels/FullScreenButton/FullScreenButton.tsx
+++ b/src/components/panels/FullScreenButton/FullScreenButton.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import localization from '../../../model/resources/localization';
+import { useAppDispatch, useAppSelector } from '../../../state/hooks';
+import { setFullScreen } from '../../../state/settingsSlice';
+
+import './FullScreenButton.css';
+
+export function FullScreenButton(): JSX.Element | null {
+	const isFullScreenSupported = useAppSelector(state => state.ui.isFullScreenSupported);
+	const fullScreen = useAppSelector(state => state.settings.fullScreen);
+	const appDispatch = useAppDispatch();
+
+	if (!isFullScreenSupported) {
+		return null;
+	}
+
+	return (
+		<button
+			type='button'
+			className="fullScreenButton"
+			title={localization.fullScreen}
+			onClick={() => appDispatch(setFullScreen(!fullScreen))}
+		>
+			<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+				{fullScreen
+					? <>
+						<path d="M19 5L13 11M13 6V11H18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+						<path d="M5 19L11 13M11 18V13H6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+					</>
+					: <>
+						<path d="M13 11L19 5M14 5H19V10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+						<path d="M11 13L5 19M10 19H5V14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+					</>}
+			</svg>
+		</button>
+	);
+}
+
+export default FullScreenButton;

--- a/src/components/panels/UserOptions/UserOptions.tsx
+++ b/src/components/panels/UserOptions/UserOptions.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import FullScreenButton from '../FullScreenButton/FullScreenButton';
 import SettingsButton from '../SettingsButton/SettingsButton';
 import { useAppDispatch, useAppSelector } from '../../../state/hooks';
 import { showProfile } from '../../../state/uiSlice';
@@ -36,6 +37,8 @@ const UserOptions: React.FC = () => {
 
 	return (
 		<div className='userOptions'>
+			<FullScreenButton />
+
 			<SettingsButton />
 
 			<button type='button' className='userInfo' title={login} onClick={() => dispatch(showProfile(true))}>

--- a/src/components/settings/CommonSettingsView/CommonSettingsView.tsx
+++ b/src/components/settings/CommonSettingsView/CommonSettingsView.tsx
@@ -7,7 +7,6 @@ import {
 	setAppSound,
 	setAttachContentToTable,
 	setFloatingControls,
-	setFullScreen,
 	setMainMenuSound,
 	setShowVideoAvatars,
 	setSound,
@@ -20,7 +19,6 @@ import { setExternalMediaWarning } from '../../../state/tableSlice';
 
 export function CommonSettingsView(): JSX.Element {
 	const settings = useAppSelector(state => state.settings);
-	const ui = useAppSelector(state => state.ui);
 	const common = useAppSelector(state => state.common);
 	const appDispatch = useAppDispatch();
 
@@ -29,19 +27,6 @@ export function CommonSettingsView(): JSX.Element {
 			<p className="header">{localization.language}</p>
 
 			<LanguageView disabled={false} />
-
-			{ui.isFullScreenSupported
-				? <div className="settingItem">
-					<input
-						id="fullScreen"
-						type="checkbox"
-						checked={settings.fullScreen}
-						onChange={() => appDispatch(setFullScreen(!settings.fullScreen))}
-					/>
-
-					<label htmlFor="fullScreen">{localization.fullScreen}</label>
-				</div>
-				: null}
 
 			<div className="settingItem">
 				<input


### PR DESCRIPTION
Кнопка полноэкранного режима перенесена из настроек в отдельную кнопку рядом с кнопкой настроек.

Причина:
Многие игроки не знают, что эта функция находится в настройках, либо не знают о клавише F11.

https://github.com/user-attachments/assets/2196b3c7-a1d5-4342-b55a-58a45d66001c