### PR TITLE
Дублирование комментария пакета в чат

### DIFF
--- a/src/logic/ClientController.ts
+++ b/src/logic/ClientController.ts
@@ -1030,6 +1030,7 @@ export default class ClientController implements IClientController {
 	onPackageComments(comments: string) {
 		this.appDispatch(captionChanged(localization.packageComments));
 		this.appDispatch(showText(comments));
+		this.addSimpleMessage(`${localization.packageComments}: ${comments}`);
 	}
 
 	onPackageDate(packageDate: string) {


### PR DESCRIPTION
Игроки зачастую пропускают комментарий, поэтому, как мне кажется, стоит продублировать его в чат, чтобы его увидело больше людей.


https://github.com/user-attachments/assets/03a3401c-df31-43fe-bec4-4afe8d01361b

