### PR TITLE
Добавить выбор источника скачивания (SiBrowser / Steam)

### DIFF
--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -149,7 +149,7 @@ class ManagedHost implements IHost {
 		return undefined;
 	}
 
-	getFallbackPackageSource(): string | undefined {
+	getAlternativePackageSource(): string | undefined {
 		return undefined;
 	}
 }

--- a/src/components/panels/Trends/Trends.scss
+++ b/src/components/panels/Trends/Trends.scss
@@ -39,6 +39,12 @@
 	margin-bottom: 5px;
 }
 
+.packageLinks {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
 .downloadButton {
 	border: none;
 	background: rgba(255, 255, 255, 0.1);
@@ -57,6 +63,12 @@
 	svg {
 		color: white;
 		transition: transform 0.2s ease;
+	}
+
+	img {
+		width: 16px;
+		height: 16px;
+		object-fit: contain;
 	}
 
 	&:hover {

--- a/src/components/panels/Trends/Trends.tsx
+++ b/src/components/panels/Trends/Trends.tsx
@@ -6,6 +6,7 @@ import clearUrls from '../../../utils/clearUrls';
 import { useAppSelector } from '../../../state/hooks';
 import { trimLength } from '../../../utils/StringHelpers';
 import TabControl from '../../common/TabControl/TabControl';
+import steamLogo from '../../../../assets/images/steam_logo.png';
 
 import './Trends.scss';
 
@@ -27,27 +28,44 @@ function isValidSourceForDownload(source?: string): boolean {
 		(source.startsWith('http://') || source.startsWith('https://'));
 }
 
-function downloadPackage(source: string, packageName: string): void {
-	try {
-		// Create a temporary anchor element to trigger download
-		const link = document.createElement('a');
-		link.href = source;
-
-		// Sanitize the package name for use as filename
-		const sanitizedName = packageName.replace(/[<>:"/\\|?*]/g, '_');
-		link.download = `${sanitizedName}.siq`;
-		link.target = '_blank';
-		link.rel = 'noopener noreferrer';
-
-		// Append to document, click, and remove
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
-	} catch (error) {
-		console.error('Failed to download package:', error);
-		// Fallback: open in new tab
-		window.open(source, '_blank', 'noopener,noreferrer');
+function isSteamSource(source?: string): boolean {
+	if (!source) {
+		return false;
 	}
+
+	try {
+		return new URL(source).hostname === 'steamcommunity.com';
+	} catch {
+		return false;
+	}
+}
+
+function packageLink(source?: string): JSX.Element | null {
+	if (!isValidSourceForDownload(source)) {
+		return null;
+	}
+
+	const steam = isSteamSource(source);
+
+	return <Link
+		href={source || ''}
+		target='_blank'
+		rel='noreferrer noopener'
+		title={steam ? localization.steamWorkshop : localization.download}>
+		<div className='downloadButton'>
+			{steam
+				? <img src={steamLogo} alt='Steam' />
+				: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path
+						d="M12 2V16M12 16L16 12M12 16L8 12M3 20H21"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>}
+		</div>
+	</Link>;
 }
 
 export default function Trends(): JSX.Element {
@@ -74,25 +92,10 @@ export default function Trends(): JSX.Element {
 										{commonClearUrls ? clearUrls(trimmedPackageName) : trimmedPackageName}</span>
 									</div>
 
-									{isValidSourceForDownload(p.package.source) && (
-										<Link
-											href={p.package.source || ''}
-											target='_blank'
-											rel='noreferrer noopener'
-											title={localization.download}>
-											<div className='downloadButton'>
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-													<path
-														d="M12 2V16M12 16L16 12M12 16L8 12M3 20H21"
-														stroke="currentColor"
-														strokeWidth="2"
-														strokeLinecap="round"
-														strokeLinejoin="round"
-													/>
-												</svg>
-											</div>
-										</Link>
-									)}
+									<div className='packageLinks'>
+										{packageLink(p.package.source)}
+										{packageLink(p.alternativeSource)}
+									</div>
 								</div>
 
 								<div className='property'>

--- a/src/host/BrowserHost.ts
+++ b/src/host/BrowserHost.ts
@@ -141,7 +141,7 @@ export default class BrowserHost implements IHost {
 		return 'https://www.sibrowser.ru'; // Using this source for statistics for now
 	}
 
-	getFallbackPackageSource(): string | undefined {
-		return undefined;
+	getAlternativePackageSource(): string | undefined {
+		return 'https://steamcommunity.com'; // Packages are also published in Steam Workshop
 	}
 }

--- a/src/host/IHost.ts
+++ b/src/host/IHost.ts
@@ -74,7 +74,8 @@ export default interface IHost {
 
 	getPackageSource(packageId?: string): string | undefined;
 
-	getFallbackPackageSource(): string | undefined;
+	/** Gets an alternative package storage that is queried in addition to the primary one. */
+	getAlternativePackageSource(): string | undefined;
 
 	/**
 	 * Upload a package directly to the content service (bypassing web transfer).

--- a/src/host/SteamTauriHost.ts
+++ b/src/host/SteamTauriHost.ts
@@ -158,7 +158,7 @@ export default class SteamTauriHost extends TauriHost {
 			: 'https://steamcommunity.com';
 	}
 
-	getFallbackPackageSource(): string | undefined {
+	getAlternativePackageSource(): string | undefined {
 		return 'https://www.sibrowser.ru';
 	}
 }

--- a/src/host/TauriHost.ts
+++ b/src/host/TauriHost.ts
@@ -359,8 +359,8 @@ export default class TauriHost implements IHost {
 		return 'https://www.sibrowser.ru'; // Using this source for statistics for now
 	}
 
-	getFallbackPackageSource(): string | undefined {
-		return undefined;
+	getAlternativePackageSource(): string | undefined {
+		return 'https://steamcommunity.com'; // Packages are also published in Steam Workshop
 	}
 
 	/**

--- a/src/host/YandexHost.ts
+++ b/src/host/YandexHost.ts
@@ -159,7 +159,7 @@ export default class YandexHost implements IHost {
 		return 'http://non-existent-package-source'; // External links are prohibited
 	}
 
-	getFallbackPackageSource(): string | undefined {
+	getAlternativePackageSource(): string | undefined {
 		return undefined;
 	}
 }

--- a/src/state/online2Slice.ts
+++ b/src/state/online2Slice.ts
@@ -2,7 +2,8 @@ import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import GameInfo from '../client/contracts/GameInfo';
 import PersonInfo from '../client/contracts/PersonInfo';
 import GamesResponse from 'sistatistics-client/dist/models/GamesResponse';
-import PackagesStatistic from 'sistatistics-client/dist/models/PackagesStatistic';
+import PackageStatistic from 'sistatistics-client/dist/models/PackageStatistic';
+import PackageInfo from 'sistatistics-client/dist/models/PackageInfo';
 import GamesFilter from '../model/enums/GamesFilter';
 import DataContext from '../model/DataContext';
 import IGameServerClient from '../client/IGameServerClient';
@@ -17,6 +18,17 @@ import Slice from '../client/contracts/Slice';
 import clearUrls from '../utils/clearUrls';
 import { filterGames } from '../utils/GamesHelpers';
 
+/** Defines a top package statistic extended with a package link in an alternative package storage. */
+export interface TopPackage extends PackageStatistic {
+	/** Package link in an alternative package storage. */
+	alternativeSource?: string;
+}
+
+/** Defines a top packages statistic. */
+export interface TopPackages {
+	packages: TopPackage[];
+}
+
 export interface Online2State {
 	inProgress: boolean;
 	error: string;
@@ -29,7 +41,7 @@ export interface Online2State {
 	uploadPackageProgress: boolean;
 	uploadPackagePercentage: number;
 	latestGames?: GamesResponse;
-	packagesStatistics?: PackagesStatistic;
+	packagesStatistics?: TopPackages;
 	password: string;
 	newGameShown: boolean;
 	gameCreationProgress: boolean;
@@ -80,6 +92,11 @@ export const loadGames = createAsyncThunk(
 	},
 );
 
+/** Identifies a package across package storages. Package hash is not provided by the statistics service, so name and authors are used. */
+function getPackageKey(info: PackageInfo): string {
+	return `${info.name}\n${info.authors.join(',')}`;
+}
+
 async function loadStatisticsAsync(dispatch: AppDispatch, dataContext: DataContext) {
 	const siStatisticsClient = new SIStatisticsClient({ serviceUri: dataContext.config.siStatisticsServiceUri });
 
@@ -104,13 +121,40 @@ async function loadStatisticsAsync(dispatch: AppDispatch, dataContext: DataConte
 		languageCode: localization.getLanguage()
 	};
 
-	const packagesStatistics = await siStatisticsClient.getLatestTopPackagesAsync({
-		statisticFilter: packagesFilter,
-		packageSource: dataContext.host.getPackageSource(),
-		fallbackSource: dataContext.host.getFallbackPackageSource(),
+	const alternativeSource = dataContext.host.getAlternativePackageSource();
+
+	// The service resolves a single link per package, so an alternative package storage is requested separately.
+	// Alternative links are optional: their loading error must not hide the whole statistics
+	const [packagesStatistics, alternativePackages] = await Promise.all([
+		siStatisticsClient.getLatestTopPackagesAsync({
+			statisticFilter: packagesFilter,
+			packageSource: dataContext.host.getPackageSource(),
+		}),
+		alternativeSource
+			? siStatisticsClient.getLatestTopPackagesAsync({
+				statisticFilter: packagesFilter,
+				packageSource: alternativeSource,
+			}).catch(error => {
+				console.warn('Could not load alternative package sources:', error);
+				return null;
+			})
+			: null,
+	]);
+
+	const alternativeSources = new Map<string, string>();
+
+	alternativePackages?.packages.forEach(p => {
+		if (p.package.source) {
+			alternativeSources.set(getPackageKey(p.package), p.package.source);
+		}
 	});
 
-	dispatch(packagesStatisticsLoaded(packagesStatistics));
+	dispatch(packagesStatisticsLoaded({
+		packages: packagesStatistics.packages.map(p => ({
+			...p,
+			alternativeSource: alternativeSources.get(getPackageKey(p.package)),
+		})),
+	}));
 
 	const latestGames = await siStatisticsClient.getLatestGamesInfoAsync(gamesFilter);
 	dispatch(latestGamesLoaded(latestGames));
@@ -192,7 +236,7 @@ export const online2Slice = createSlice({
 		latestGamesLoaded: (state: Online2State, action: PayloadAction<GamesResponse>) => {
 			state.latestGames = action.payload;
 		},
-		packagesStatisticsLoaded: (state: Online2State, action: PayloadAction<PackagesStatistic>) => {
+		packagesStatisticsLoaded: (state: Online2State, action: PayloadAction<TopPackages>) => {
 			state.packagesStatistics = action.payload;
 		},
 		passwordChanged: (state: Online2State, action: PayloadAction<string>) => {

--- a/test/GameIntegration.test.ts
+++ b/test/GameIntegration.test.ts
@@ -163,7 +163,7 @@ class TestHost implements IHost {
 		return undefined;
 	}
 
-	getFallbackPackageSource(): string | undefined {
+	getAlternativePackageSource(): string | undefined {
 		return undefined;
 	}
 }

--- a/test/languageChange.test.ts
+++ b/test/languageChange.test.ts
@@ -38,7 +38,7 @@ class TestHost implements IHost {
 	async addGameLog(): Promise<boolean> { return true; }
 	async openGameLog(): Promise<boolean> { return true; }
 	getPackageSource(): string | undefined { return undefined; }
-	getFallbackPackageSource(): string | undefined { return undefined; }
+	getAlternativePackageSource(): string | undefined { return undefined; }
 }
 
 describe('Language change on initial load', () => {


### PR DESCRIPTION
Теперь можно выбрать, откуда скачать пакет - из SiBrowser или Steam.
Это решает сразу 2 проблемы:
1) Если обновить файл siq в ВК, ссылка в SiBrowser тоже изменится, из-за чего старая ссылка на скачивание перестанет работать.
2) При игре через браузер, если пакет доступен только в Steam, кнопка скачивания раньше и вовсе отсутствовала.

https://github.com/user-attachments/assets/a42cc3e0-062b-459f-a391-e604b370fbf5

