### PR TITLE
Показ процентов попыток и правильных ответов во время ответа

### DIFF
--- a/src/components/gameTable/GameTable/GameTable.css
+++ b/src/components/gameTable/GameTable/GameTable.css
@@ -12,6 +12,7 @@
 
 .tableCaption {
     flex: 0 0 45px;
+    position: relative;
     background: rgba(0, 0, 0, 0.3);
     font-size: 22px;
     display: flex;
@@ -48,6 +49,34 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+}
+
+/* Pinned out of the caption flow, the offset reserving the collapsed volume button width */
+.questionStats {
+    position: absolute;
+    top: 50%;
+    right: 40px;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 16px;
+    white-space: nowrap;
+}
+
+/* The volume slider is expanded from this width on */
+@media screen and (min-width: 769px) {
+    .questionStats {
+        right: 148px;
+    }
+}
+
+.questionStats__tries {
+    color: #ffcc00;
+}
+
+.questionStats__right {
+    color: #28a745;
 }
 
 .tableCaptionContent {

--- a/src/components/gameTable/GameTable/GameTable.tsx
+++ b/src/components/gameTable/GameTable/GameTable.tsx
@@ -10,6 +10,7 @@ import AutoSizedText from '../../common/AutoSizedText/AutoSizedText';
 import localization from '../../../model/resources/localization';
 import ProgressBar from '../../common/ProgressBar/ProgressBar';
 import { isRunning } from '../../../utils/TimerInfoHelpers';
+import { getQuestionStatsPercents, getQuestionStatsPosition } from '../../../utils/QuestionStatsHelpers';
 import TableContent from '../TableContent/TableContent';
 import ObjectView from '../ObjectView/ObjectView';
 import { useAppSelector } from '../../../state/hooks';
@@ -113,6 +114,14 @@ export function GameTable(): JSX.Element {
 	const decisionTimer = useAppSelector((state) => state.room2.timers.decision);
 	const answerDeviation = useAppSelector((state) => state.table.answerDeviation);
 	const layoutMode = useAppSelector((state) => state.table.layoutMode);
+	const isAnswer = useAppSelector((state) => state.table.isAnswer);
+	const activeThemeIndex = useAppSelector((state) => state.table.activeThemeIndex);
+	const actionQuestionIndex = useAppSelector((state) => state.table.actionQuestionIndex);
+	const roundIndex = useAppSelector((state) => state.room.stage.roundIndex);
+	const roundInfo = useAppSelector((state) => state.table.roundInfo);
+	const themeName = useAppSelector((state) => state.room2.theme.name);
+	const packageStats = useAppSelector((state) => state.room2.playState.packageStats);
+	const completedGameCount = useAppSelector((state) => state.room2.playState.completedGameCount);
 
 	const shouldShowAnswerValidationInTable = decisionType === DecisionType.Validation &&
 		validationQueue.length > 0 &&
@@ -121,6 +130,15 @@ export function GameTable(): JSX.Element {
 	const caption = shouldShowAnswerValidationInTable
 		? localization.validateAnswer
 		: getCaption(mode, tableCaption);
+
+	const questionStats = isAnswer || caption === localization.rightAnswer
+		? getQuestionStatsPercents(
+			packageStats,
+			completedGameCount,
+			roundIndex,
+			getQuestionStatsPosition(roundInfo, themeName, activeThemeIndex, actionQuestionIndex),
+		)
+		: null;
 
 	const themeProperties: React.CSSProperties = {};
 	const reversedPropeties: React.CSSProperties = {};
@@ -158,6 +176,12 @@ export function GameTable(): JSX.Element {
 					</div>
 					<div className='tableCaptionContent'>{caption}</div>
 					<div className='caption__right'>
+						{questionStats ? (
+							<div className='questionStats'>
+								<span className='questionStats__tries' title={localization.answerTries}>{questionStats.triesPercent}%</span>
+								<span className='questionStats__right' title={localization.rightAnswers}>{questionStats.rightPercent}%</span>
+							</div>
+						) : null}
 						{hasSound && <VolumeButton canPlayAudio={canPlayAudio} />}
 					</div>
 				</div>

--- a/src/logic/ClientController.ts
+++ b/src/logic/ClientController.ts
@@ -118,6 +118,7 @@ import {
 	setIsPaused,
 	setRoomRole,
 	incrementQuestionCounter,
+	loadPackageStats,
 	resetQuestionCounter,
 	setTheme,
 	setSettingDisplayAnswerOptionsLabels,
@@ -1031,6 +1032,12 @@ export default class ClientController implements IClientController {
 
 	onPackageAuthors(authors: string[]) {
 		this.appDispatch(setPackageAuthors(authors));
+
+		const { packageName } = this.getState().room.metadata;
+
+		if (packageName) {
+			this.appDispatch(loadPackageStats({ name: packageName, authors }));
+		}
 
 		this.appDispatch(showObject({
 			header: '',

--- a/src/state/online/onlineActionCreators.ts
+++ b/src/state/online/onlineActionCreators.ts
@@ -36,6 +36,7 @@ import {
 	ContextView,
 	DecisionType,
 	nameChanged,
+	resetPackageStats,
 	resetQuestionCounter,
 	setAreSumsEditable,
 	setContext,
@@ -138,6 +139,7 @@ const initGameAsync = async (
 	dispatch(roomActionCreators.isQuestionChanged(false, ''));
 	appDispatch(setAreSumsEditable(false));
 	appDispatch(resetQuestionCounter());
+	appDispatch(resetPackageStats());
 	appDispatch(setRoundsNames([]));
 
 	appDispatch(initRoom());

--- a/src/state/room2Slice.ts
+++ b/src/state/room2Slice.ts
@@ -1,4 +1,6 @@
 import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import SIStatisticsClient from 'sistatistics-client';
+import QuestionStats from 'sistatistics-client/dist/models/QuestionStats';
 import DataContext from '../model/DataContext';
 import PlayerInfo from '../model/PlayerInfo';
 import PersonInfo from '../model/PersonInfo';
@@ -71,6 +73,11 @@ export interface Room2State {
 
 	playState: {
 		packageUri: string | null;
+
+		// Package question statistics keyed by roundIndex:themeIndex:questionIndex
+		packageStats: Record<string, QuestionStats>;
+
+		completedGameCount: number;
 	};
 
 	dialogView: DialogView;
@@ -162,6 +169,8 @@ const initialState: Room2State = {
 
 	playState: {
 		packageUri: null,
+		packageStats: {},
+		completedGameCount: 0,
 	},
 
 	dialogView: DialogView.None,
@@ -433,6 +442,24 @@ export const toggleQuestion = createAsyncThunk(
 	async (arg: { themeIndex: number, questionIndex: number }, thunkAPI) => {
 		const dataContext = thunkAPI.extra as DataContext;
 		await dataContext.game.toggle(arg.themeIndex, arg.questionIndex);
+	},
+);
+
+export const loadPackageStats = createAsyncThunk(
+	'room2/loadPackageStats',
+	async (arg: { name: string, authors: string[] }, thunkAPI) => {
+		const dataContext = thunkAPI.extra as DataContext;
+		const siStatisticsClient = new SIStatisticsClient({ serviceUri: dataContext.config.siStatisticsServiceUri });
+
+		try {
+			return await siStatisticsClient.getPackageStats({ name: arg.name, hash: '', authors: arg.authors });
+		} catch (error: unknown) {
+			// Return empty stats on 404 or other errors
+			return {
+				topLevelStats: { startedGameCount: 0, completedGameCount: 0 },
+				questionStats: {},
+			};
+		}
 	},
 );
 
@@ -804,6 +831,10 @@ export const room2Slice = createSlice({
 		resetQuestionCounter(state: Room2State) {
 			state.stage.questionCounter = 0;
 		},
+		resetPackageStats(state: Room2State) {
+			state.playState.packageStats = {};
+			state.playState.completedGameCount = 0;
+		},
 		setSettingDisplayAnswerOptionsLabels: (state: Room2State, action: PayloadAction<boolean>) => {
 			state.settings.displayAnswerOptionsLabels = action.payload;
 		},
@@ -1096,6 +1127,11 @@ export const room2Slice = createSlice({
 			state.stage.decisionType = DecisionType.None;
 		});
 
+		builder.addCase(loadPackageStats.fulfilled, (state, action) => {
+			state.playState.packageStats = action.payload.questionStats;
+			state.playState.completedGameCount = action.payload.topLevelStats.completedGameCount;
+		});
+
 		builder.addCase(approveAnswerDefault.fulfilled, (state) => {
 			state.validation.queue.shift();
 			state.stage.decisionType = DecisionType.None;
@@ -1385,6 +1421,7 @@ export const {
 	setRoomRole,
 	incrementQuestionCounter,
 	resetQuestionCounter,
+	resetPackageStats,
 	setSettingDisplayAnswerOptionsLabels,
 	setSettingFalseStart,
 	setSettingOral,

--- a/src/utils/QuestionStatsHelpers.ts
+++ b/src/utils/QuestionStatsHelpers.ts
@@ -1,0 +1,78 @@
+import QuestionStats from 'sistatistics-client/dist/models/QuestionStats';
+import ThemeInfo from '../model/ThemeInfo';
+
+/** Minimum number of completed games required to display package question statistics. */
+export const MIN_COMPLETED_GAME_COUNT = 20;
+
+/** Question position inside a round. Indices are -1 when unknown. */
+export interface QuestionStatsPosition {
+	themeIndex: number;
+	questionIndex: number;
+}
+
+/** Question answer percentages. */
+export interface QuestionStatsPercents {
+	triesPercent: number;
+	rightPercent: number;
+}
+
+const UNKNOWN_POSITION: QuestionStatsPosition = { themeIndex: -1, questionIndex: -1 };
+
+export function getQuestionStatsKey(roundIndex: number, themeIndex: number, questionIndex: number): string {
+	return `${roundIndex}:${themeIndex}:${questionIndex}`;
+}
+
+/** Resolves the position of the currently played question inside the round.
+ * The server reports it for round table questions only, so theme list questions are resolved by theme name,
+ * and only when the name matches a single theme holding no question prices.
+ */
+export function getQuestionStatsPosition(
+	roundInfo: ThemeInfo[],
+	themeName: string,
+	activeThemeIndex: number,
+	actionQuestionIndex: number,
+): QuestionStatsPosition {
+	if (actionQuestionIndex > -1) {
+		return { themeIndex: activeThemeIndex, questionIndex: actionQuestionIndex };
+	}
+
+	if (themeName.length === 0) {
+		return UNKNOWN_POSITION;
+	}
+
+	const matchedIndices = roundInfo.reduce<number[]>(
+		(indices, theme, themeIndex) => (theme.name === themeName && theme.questions.length === 0
+			? [...indices, themeIndex]
+			: indices),
+		[],
+	);
+
+	return matchedIndices.length === 1 ? { themeIndex: matchedIndices[0], questionIndex: 0 } : UNKNOWN_POSITION;
+}
+
+/** Calculates question answer percentages. Returns null when there is nothing to display. */
+export function getQuestionStatsPercents(
+	packageStats: Record<string, QuestionStats>,
+	completedGameCount: number,
+	roundIndex: number,
+	position: QuestionStatsPosition,
+): QuestionStatsPercents | null {
+	const { themeIndex, questionIndex } = position;
+
+	if (completedGameCount < MIN_COMPLETED_GAME_COUNT || roundIndex < 0 || themeIndex < 0 || questionIndex < 0) {
+		return null;
+	}
+
+	const stats = packageStats[getQuestionStatsKey(roundIndex, themeIndex, questionIndex)];
+
+	if (!stats || stats.shownCount <= 0 || stats.playerSeenCount <= 0) {
+		return null;
+	}
+
+	const tryCount = stats.correctCount + stats.wrongCount;
+
+	return {
+		triesPercent: Math.round((stats.answeredCount / stats.shownCount) * 100),
+		rightPercent: tryCount > 0 ? Math.round((stats.correctCount / tryCount) * 100) : 0,
+	};
+}

--- a/test/QuestionStatsHelpers.test.ts
+++ b/test/QuestionStatsHelpers.test.ts
@@ -1,0 +1,132 @@
+import QuestionStats from 'sistatistics-client/dist/models/QuestionStats';
+import ThemeInfo from '../src/model/ThemeInfo';
+import {
+	MIN_COMPLETED_GAME_COUNT,
+	getQuestionStatsKey,
+	getQuestionStatsPercents,
+	getQuestionStatsPosition,
+} from '../src/utils/QuestionStatsHelpers';
+
+/** Themes of a theme list round: they hold no question prices. */
+function makeThemeListRound(...names: string[]): ThemeInfo[] {
+	return names.map(name => ({ name, comment: '', questions: [] }));
+}
+
+/** Themes of a round table round: they hold question prices. */
+function makeTableRound(...names: string[]): ThemeInfo[] {
+	return names.map(name => ({ name, comment: '', questions: [100, 200, 300] }));
+}
+
+function makeStats(overrides: Partial<QuestionStats> = {}): QuestionStats {
+	return {
+		shownCount: 100,
+		playerSeenCount: 100,
+		answeredCount: 80,
+		correctCount: 40,
+		wrongCount: 40,
+		...overrides,
+	};
+}
+
+function makePackageStats(stats: QuestionStats, key = '0:0:0'): Record<string, QuestionStats> {
+	return { [key]: stats };
+}
+
+describe('getQuestionStatsKey', () => {
+	test('builds key from round, theme and question indices', () => {
+		expect(getQuestionStatsKey(0, 2, 3)).toBe('0:2:3');
+	});
+});
+
+describe('getQuestionStatsPosition', () => {
+	test('uses position reported by the server for round table questions', () => {
+		const round = makeTableRound('Кино', 'Музыка');
+		expect(getQuestionStatsPosition(round, 'Музыка', 1, 3)).toEqual({ themeIndex: 1, questionIndex: 3 });
+	});
+
+	test('resolves theme list question by theme name, as the server reports no position', () => {
+		const round = makeThemeListRound('Кино', 'Музыка', 'Спорт');
+		expect(getQuestionStatsPosition(round, 'Спорт', -1, -1)).toEqual({ themeIndex: 2, questionIndex: 0 });
+	});
+
+	test('resolves the surviving theme when played out themes are already blanked', () => {
+		const round = makeThemeListRound('', 'Музыка', '');
+		expect(getQuestionStatsPosition(round, 'Музыка', -1, -1)).toEqual({ themeIndex: 1, questionIndex: 0 });
+	});
+
+	test('gives up when the theme name is ambiguous', () => {
+		const round = makeThemeListRound('Кино', 'Кино');
+		expect(getQuestionStatsPosition(round, 'Кино', -1, -1)).toEqual({ themeIndex: -1, questionIndex: -1 });
+	});
+
+	test('gives up when the theme name is unknown', () => {
+		const round = makeThemeListRound('Кино', 'Музыка');
+		expect(getQuestionStatsPosition(round, 'Спорт', -1, -1)).toEqual({ themeIndex: -1, questionIndex: -1 });
+	});
+
+	test('never matches blanked themes by an empty name', () => {
+		const round = makeThemeListRound('', 'Музыка');
+		expect(getQuestionStatsPosition(round, '', -1, -1)).toEqual({ themeIndex: -1, questionIndex: -1 });
+	});
+
+	test('does not guess round table questions by name, as their position must come from the server', () => {
+		const round = makeTableRound('Кино', 'Музыка');
+		expect(getQuestionStatsPosition(round, 'Музыка', -1, -1)).toEqual({ themeIndex: -1, questionIndex: -1 });
+	});
+});
+
+describe('getQuestionStatsPercents', () => {
+	test('calculates tries percent of shown count and right percent of tries', () => {
+		const result = getQuestionStatsPercents(makePackageStats(makeStats()), MIN_COMPLETED_GAME_COUNT, 0, { themeIndex: 0, questionIndex: 0 });
+		expect(result).toEqual({ triesPercent: 80, rightPercent: 50 });
+	});
+
+	test('rounds percentages', () => {
+		const stats = makeStats({ shownCount: 3, answeredCount: 1, correctCount: 1, wrongCount: 2 });
+		expect(getQuestionStatsPercents(makePackageStats(stats), 100, 0, { themeIndex: 0, questionIndex: 0 })).toEqual({ triesPercent: 33, rightPercent: 33 });
+	});
+
+	test('reads statistics of the requested question only', () => {
+		const packageStats = {
+			...makePackageStats(makeStats(), '0:0:0'),
+			...makePackageStats(makeStats({ answeredCount: 10, correctCount: 1, wrongCount: 9 }), '1:2:3'),
+		};
+
+		expect(getQuestionStatsPercents(packageStats, 100, 1, { themeIndex: 2, questionIndex: 3 })).toEqual({ triesPercent: 10, rightPercent: 10 });
+	});
+
+	test('returns null when the question has no statistics', () => {
+		expect(getQuestionStatsPercents(makePackageStats(makeStats()), 100, 5, { themeIndex: 5, questionIndex: 5 })).toBeNull();
+	});
+
+	test('returns null when the package has not been completed enough times', () => {
+		expect(getQuestionStatsPercents(makePackageStats(makeStats()), MIN_COMPLETED_GAME_COUNT - 1, 0, { themeIndex: 0, questionIndex: 0 })).toBeNull();
+	});
+
+	test('returns null when the question position is unknown', () => {
+		const packageStats = makePackageStats(makeStats(), '0:-1:-1');
+		expect(getQuestionStatsPercents(packageStats, 100, 0, { themeIndex: -1, questionIndex: -1 })).toBeNull();
+	});
+
+	test('returns null when the round is unknown', () => {
+		expect(getQuestionStatsPercents(makePackageStats(makeStats(), '-1:0:0'), 100, -1, { themeIndex: 0, questionIndex: 0 })).toBeNull();
+	});
+
+	test('returns null when the question has never been shown (would divide by zero)', () => {
+		expect(getQuestionStatsPercents(makePackageStats(makeStats({ shownCount: 0 })), 100, 0, { themeIndex: 0, questionIndex: 0 })).toBeNull();
+	});
+
+	test('returns null when no player has seen the question', () => {
+		expect(getQuestionStatsPercents(makePackageStats(makeStats({ playerSeenCount: 0 })), 100, 0, { themeIndex: 0, questionIndex: 0 })).toBeNull();
+	});
+
+	test('returns zero right percent when nobody tried to answer', () => {
+		const stats = makeStats({ answeredCount: 0, correctCount: 0, wrongCount: 0 });
+		expect(getQuestionStatsPercents(makePackageStats(stats), 100, 0, { themeIndex: 0, questionIndex: 0 })).toEqual({ triesPercent: 0, rightPercent: 0 });
+	});
+
+	test('handles real service data', () => {
+		const stats = makeStats({ shownCount: 23858, playerSeenCount: 78893, answeredCount: 19057, correctCount: 16928, wrongCount: 3601 });
+		expect(getQuestionStatsPercents(makePackageStats(stats), 16083, 0, { themeIndex: 0, questionIndex: 0 })).toEqual({ triesPercent: 80, rightPercent: 82 });
+	});
+});


### PR DESCRIPTION
Во время показа правильного ответа, сверху, рядом с ползунком громкости, отображается процент попыток ответа и процент правильных ответов. Если у пакета меньше 20 завершённых игр, статистика не показывается, чтобы избежать нерепрезентативной выборки.
Причина добавления:
Игроки иногда жалуются, что вопросы слишком сложные и что якобы на них никто не отвечает. Также бывают претензии к стоимости вопросов, например, что вопрос за 100 сложнее, чем за 200, хотя статистика показывает обратное. Такая статистика позволяет объективно оценить сложность вопроса и в целом даёт полезный контекст.

Примечание:
Пока работает только для игроков, что зашли в начале игры, до запуска. Если зайти в середине игры - статистики не будет. Исправляется вроде как ещё одним PR в другом репо (SI), но я подожду, пока этот будет принят.

https://github.com/user-attachments/assets/df36bf58-7e4d-42d2-b596-1cb416e7cd2b

