### PR TITLE
Сохранение ссылки на голосовой чат после перезапуска вкладки

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -105,6 +105,7 @@ function setState(state: State, savedState: SavedState | null, c: Config, isDesk
 			...state.game,
 			name: savedState.game.name,
 			password: savedState.game.password,
+			voiceChat: savedState.game.voiceChat ?? '',
 			role: savedState.game.role,
 			type: savedState.game.type,
 			playersCount: savedState.game.playersCount,

--- a/src/state/SavedState.ts
+++ b/src/state/SavedState.ts
@@ -11,6 +11,7 @@ export default interface SavedState {
 	game: {
 		name: string;
 		password: string;
+		voiceChat: string;
 		role: Role;
 		type: GameType;
 		playersCount: number;

--- a/src/state/StateHelpers.ts
+++ b/src/state/StateHelpers.ts
@@ -8,6 +8,7 @@ export function saveStateToStorage(state: RootState): void {
 		game: {
 			name: state.game.name,
 			password: state.game.password,
+			voiceChat: state.game.voiceChat,
 			role: state.game.role,
 			type: state.game.type,
 			playersCount: state.game.playersCount,


### PR DESCRIPTION
Теперь помимо названия комнаты, пароля и других настроек сохраняется также ссылка на голосовой чат.
Причина:
У многих пользователей ссылка на голосовой чат не меняется, поэтому каждый раз вставлять её заново было неудобно. Лично я иногда просто забывал это сделать.
(В первой части видео показано, как это работает теперь, во второй - как было раньше)
https://github.com/user-attachments/assets/26ea758a-4849-4a1b-be94-41c2940a39e9

